### PR TITLE
Fixed problem with mutually exclusive parameters to unarchive

### DIFF
--- a/tasks/platforms/ubuntu.yml
+++ b/tasks/platforms/ubuntu.yml
@@ -55,7 +55,6 @@
     src: "/tmp/{{ artifactory_database_file_title }}.tar.gz"
     dest: /tmp
     creates: "/tmp/{{ artifactory_database_file_title }}/"
-    copy: no
     remote_src: yes
   when: artifactory_database_jdbc_url is defined and not jdbc_installed.stat.exists
 


### PR DESCRIPTION
When testing your role with Ansible Version 2.2.0.0, I received an error stating that for unarchive (used in the ubuntu task) should use either "copy" (which is deprecated) or "remote_src", but not both.
Therefore I removed the copy instruction.