### PR TITLE
Add HTTPS transport for APT on Debian

### DIFF
--- a/tasks/platforms/debian.yml
+++ b/tasks/platforms/debian.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Add apt transport for https
+  apt:
+    name: apt-transport-https
+    state: present
+
+- include: ubuntu.yml


### PR DESCRIPTION
On Debian, the HTTPS transport for APT is not installed by default.
Apart from that, the Ubuntu settings work fine for Debian.